### PR TITLE
Deployment clean up

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# rename to .env and set the variables
+
+DOCKETBIRD_API_KEY=your_api_key_here

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,12 @@ name = "docketbird-mcp"
 version = "0.1.0"
 dependencies = [
     "mcp>=1.2.0",
-    "requests>=2.31.0",
-    "python-dotenv>=1.0.0"
+    "requests>=2.31.0", 
+    "python-dotenv>=1.0.0",
+    "fastapi",
+    "uvicorn",
+    "pydantic",
+    "termcolor"
 ]
 
 [build-system]

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+import os
+import sys
+import time
+import subprocess
+import json
+from termcolor import colored
+
+# Add parent directory to path to import from docketbird_mcp if needed
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# CONFIGURATION VARIABLES
+SERVER_IP = os.getenv(
+    "SERVER_IP", "165.227.221.151"
+)  # Default from README-Deployment.md
+SSH_KEY_PATH = os.getenv("SSH_KEY_PATH", "~/.ssh/do_droplet")  # Path to SSH key
+SSH_USER = os.getenv("SSH_USER", "root")  # Default SSH user
+DOCKETBIRD_API_KEY = os.getenv(
+    "DOCKETBIRD_API_KEY", "dummy_key_for_testing"
+)  # Default dummy key for testing
+
+
+def print_colored(message, color="white", status=None):
+    """Print a colored message with optional status prefix."""
+    status_prefix = ""
+    if status == "info":
+        status_prefix = colored("[INFO] ", "blue")
+    elif status == "success":
+        status_prefix = colored("[SUCCESS] ", "green")
+    elif status == "error":
+        status_prefix = colored("[ERROR] ", "red")
+    elif status == "warning":
+        status_prefix = colored("[WARNING] ", "yellow")
+
+    print(f"{status_prefix}{colored(message, color)}")
+
+
+def check_environment_variables():
+    """Check if required environment variables are set."""
+    print_colored("Checking environment variables...", status="info")
+
+    missing_vars = []
+    if not SERVER_IP:
+        missing_vars.append("SERVER_IP")
+
+    if missing_vars:
+        print_colored(
+            f"Missing required environment variables: {', '.join(missing_vars)}",
+            status="error",
+        )
+        print_colored("Please set them before running this script:", status="info")
+        print_colored("export SERVER_IP=your_droplet_ip", "yellow")
+        sys.exit(1)
+
+    print_colored("Environment variables are properly set.", status="success")
+    print_colored(f"Using SERVER_IP: {SERVER_IP}", status="info")
+    print_colored(f"Using SSH_KEY_PATH: {SSH_KEY_PATH}", status="info")
+
+    if DOCKETBIRD_API_KEY == "dummy_key_for_testing":
+        print_colored(
+            "DOCKETBIRD_API_KEY not set, using dummy key for testing", status="warning"
+        )
+    else:
+        print_colored(
+            f"DOCKETBIRD_API_KEY is set (first 5 chars): {DOCKETBIRD_API_KEY[:5]}...",
+            status="info",
+        )
+
+
+def run_ssh_command(command):
+    """Run a command on the remote server via SSH."""
+    ssh_command = [
+        "ssh",
+        "-i",
+        os.path.expanduser(SSH_KEY_PATH),
+        f"{SSH_USER}@{SERVER_IP}",
+        command,
+    ]
+    try:
+        result = subprocess.run(ssh_command, capture_output=True, text=True)
+        if result.returncode != 0:
+            print_colored(
+                f"SSH command failed with error: {result.stderr}", status="error"
+            )
+            return None
+        return result.stdout.strip()
+    except Exception as e:
+        print_colored(f"Failed to run SSH command: {str(e)}", status="error")
+        return None
+
+
+def test_docker_container():
+    """Test if the Docker container is running."""
+    print_colored("\nChecking if Docker container is running...", status="info")
+
+    # Check if the container exists and is running
+    container_status = run_ssh_command(
+        "docker ps | grep docketbird-mcp || echo 'Container not found'"
+    )
+
+    if not container_status or "Container not found" in container_status:
+        print_colored("Container is not running or doesn't exist", status="error")
+        return False
+
+    print_colored("Container is running:", status="success")
+    print_colored(container_status, "green")
+
+    # Check container logs
+    print_colored("\nChecking container logs...", status="info")
+    container_logs = run_ssh_command("docker logs docketbird-mcp")
+
+    if not container_logs:
+        print_colored("Failed to retrieve container logs", status="error")
+        return False
+
+    print_colored("Container logs:", status="success")
+    for line in container_logs.split("\n"):
+        print_colored(f"  {line}", "cyan")
+
+    # Check if API key is properly set in the container
+    if "API Key set" in container_logs:
+        print_colored("API key is properly set in the container", status="success")
+    else:
+        print_colored(
+            "API key might not be properly set in the container", status="warning"
+        )
+
+    return True
+
+
+def main():
+    """Main test function."""
+    print_colored("=" * 70, "cyan")
+    print_colored("DocketBird MCP Server Deployment Test", "cyan")
+    print_colored("=" * 70, "cyan")
+
+    # Step 1: Check environment variables
+    check_environment_variables()
+
+    # Step 2: Test Docker container
+    container_success = test_docker_container()
+
+    # Summary
+    print_colored("\n" + "=" * 70, "cyan")
+    if container_success:
+        print_colored("✅ DEPLOYMENT TEST PASSED!", "green", status="success")
+        print_colored(
+            "The DocketBird MCP server appears to be running correctly.",
+            status="success",
+        )
+        print_colored(
+            "Note: This test only confirms the container is running, not that it's accessible.",
+            status="info",
+        )
+        print_colored(
+            "The MCP server might be designed to be accessed differently than direct TCP connections.",
+            status="info",
+        )
+    else:
+        print_colored("❌ DEPLOYMENT TEST FAILED!", "red", status="error")
+        print_colored("Please check the server logs and configuration.", status="error")
+
+    print_colored("=" * 70, "cyan")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        print_colored("\nTest interrupted by user.", status="warning")
+        sys.exit(1)
+    except Exception as e:
+        print_colored(f"An unexpected error occurred: {str(e)}", status="error")
+        sys.exit(1)

--- a/uv.lock
+++ b/uv.lock
@@ -108,16 +108,38 @@ name = "docketbird-mcp"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "fastapi" },
     { name = "mcp" },
+    { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "requests" },
+    { name = "termcolor" },
+    { name = "uvicorn" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "fastapi" },
     { name = "mcp", specifier = ">=1.2.0" },
+    { name = "pydantic" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "requests", specifier = ">=2.31.0" },
+    { name = "termcolor" },
+    { name = "uvicorn" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.115.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/55/ae499352d82338331ca1e28c7f4a63bfd09479b16395dce38cf50a39e2c2/fastapi-0.115.12.tar.gz", hash = "sha256:1e2c2a2646905f9e83d32f04a3f86aff4a286669c6c950ca95b5fd68c2602681", size = 295236 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/b3/b51f09c2ba432a576fe63758bddc81f78f0c6309d9e5c10d194313bf021e/fastapi-0.115.12-py3-none-any.whl", hash = "sha256:e94613d6c05e27be7ffebdd6ea5f388112e5e430c8f7d6494a9d1d88d43e814d", size = 95164 },
 ]
 
 [[package]]
@@ -343,6 +365,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/04/1b/52b27f2e13ceedc79a908e29eac426a63465a1a01248e5f24aa36a62aeb3/starlette-0.46.1.tar.gz", hash = "sha256:3c88d58ee4bd1bb807c0d1acb381838afc7752f9ddaec81bbe4383611d833230", size = 2580102 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/4b/528ccf7a982216885a1ff4908e886b8fb5f19862d1962f56a3fce2435a70/starlette-0.46.1-py3-none-any.whl", hash = "sha256:77c74ed9d2720138b25875133f3a2dae6d854af2ec37dceb56aef370c1d8a227", size = 71995 },
+]
+
+[[package]]
+name = "termcolor"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/b6/8e2aaa8aeb570b5cc955cd913b083d96c5447bbe27eaf330dfd7cc8e3329/termcolor-3.0.1.tar.gz", hash = "sha256:a6abd5c6e1284cea2934443ba806e70e5ec8fd2449021be55c280f8a3731b611", size = 12935 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/7e/a574ccd49ad07e8b117407bac361f1e096b01f1b620365daf60ff702c936/termcolor-3.0.1-py3-none-any.whl", hash = "sha256:da1ed4ec8a5dc5b2e17476d859febdb3cccb612be1c36e64511a6f2485c10c69", size = 7157 },
 ]
 
 [[package]]


### PR DESCRIPTION
Update pyproject.toml and uv.lock to include new dependencies: fastapi, uvicorn, pydantic, and termcolor.

Move test_deployment to tests folder.